### PR TITLE
Updated emulator README to use r21 link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can read more about it on the following page :
 # Building and running the android-10 emulator x86_64
 
 1. Fetch the code: `REPO_INIT_FLAGS="--depth=1" ./config.sh emulator-10-x86_64`
-2. Setup your environment to fetch the custom NDK: `export LOCAL_NDK_BASE_URL='ftp://ftp.kaiostech.com/ndk/android-ndk'`
+2. Setup your environment to fetch the custom NDK: `export LOCAL_NDK_BASE_URL='https://packages.preprod.kaiostech.com/ndk/android-ndk'`
 3. Install Gecko dependencies: `cd gecko && ./mach bootstrap`, choose option 1 (Boot2Gecko).
 4. Build: `./build.sh`
 5. Run the emulator: `source build/envsetup.sh && lunch aosp_arm-userdebug && emulator -writable-system -selinux permissive`

--- a/config.sh
+++ b/config.sh
@@ -30,7 +30,7 @@ case `uname` in
 	exit -1
 esac
 
-GITREPO=${GITREPO:-"https://github.com/capyloon/manifests"}
+GITREPO=${GITREPO:-"https://github.com/doctorjei/capyloon-manifests"}
 BRANCH=${BRANCH:-master}
 
 while [ $# -ge 1 ]; do


### PR DESCRIPTION
old NDK export's FTP link doesn't work for r21, but this HTTP link does.